### PR TITLE
Update Ubuntu base image to 22.04 LTS

### DIFF
--- a/.github/workflows/ubuntu-mirror.yml
+++ b/.github/workflows/ubuntu-mirror.yml
@@ -47,6 +47,15 @@ jobs:
             tags: |
               jmlntw/ubuntu-mirror:20.04
               jmlntw/ubuntu-mirror:focal
+          - build_args: |
+              BASE_IMAGE_TAG=jammy
+            platforms: |
+              linux/amd64
+              linux/arm
+              linux/arm64
+            tags: |
+              jmlntw/ubuntu-mirror:22.04
+              jmlntw/ubuntu-mirror:jammy
               jmlntw/ubuntu-mirror:latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ubuntu-taiwanize.yml
+++ b/.github/workflows/ubuntu-taiwanize.yml
@@ -47,6 +47,15 @@ jobs:
             tags: |
               jmlntw/ubuntu-taiwanize:20.04
               jmlntw/ubuntu-taiwanize:focal
+          - build_args: |
+              BASE_IMAGE_TAG=jammy
+            platforms: |
+              linux/amd64
+              linux/arm
+              linux/arm64
+            tags: |
+              jmlntw/ubuntu-taiwanize:22.04
+              jmlntw/ubuntu-taiwanize:jammy
               jmlntw/ubuntu-taiwanize:latest
     steps:
       - name: Checkout repository

--- a/ubuntu-mirror/README.md
+++ b/ubuntu-mirror/README.md
@@ -6,6 +6,7 @@ An Ubuntu Docker image automatically selecting the fastest apt mirror servers.
 
 | Tag                        | Architecture           | Base Image       |
 | -------------------------- | ---------------------- | ---------------- |
-| `20.04`, `focal`, `latest` | amd64, arm ,arm64      | Ubuntu 20.04 LTS |
+| `22.04`, `jammy`, `latest` | amd64, arm, arm64      | Ubuntu 22.04 LTS |
+| `20.04`, `focal`           | amd64, arm ,arm64      | Ubuntu 20.04 LTS |
 | `18.04`, `bionic`          | 386, amd64, arm, arm64 | Ubuntu 18.04 LTS |
 | `16.04`, `xenial`          | 386, amd64, arm, arm64 | Ubuntu 16.04 LTS |

--- a/ubuntu-taiwanize/README.md
+++ b/ubuntu-taiwanize/README.md
@@ -6,6 +6,7 @@ An Ubuntu Docker image localizing to Traditional Chinese (Taiwan).
 
 | Tag                        | Architecture           | Base Image       |
 | -------------------------- | ---------------------- | ---------------- |
-| `20.04`, `focal`, `latest` | amd64, arm ,arm64      | Ubuntu 20.04 LTS |
+| `22.04`, `jammy`, `latest` | amd64, arm, arm64      | Ubuntu 22.04 LTS |
+| `20.04`, `focal`           | amd64, arm ,arm64      | Ubuntu 20.04 LTS |
 | `18.04`, `bionic`          | 386, amd64, arm, arm64 | Ubuntu 18.04 LTS |
 | `16.04`, `xenial`          | 386, amd64, arm, arm64 | Ubuntu 16.04 LTS |


### PR DESCRIPTION
This pull request updates the latest base image to Ubuntu 22.04 LTS.
