### PR TITLE
Update Super-Linter image in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,11 @@ name: Lint
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
     branches:
+      - main
       - master
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           # within Super Linter.
           fetch-depth: 0
       - name: Run GitHub Super Linter
-        uses: github/super-linter/slim@v5
+        uses: super-linter/super-linter/slim@v5
         env:
           # Parse only new or edited files for validation.
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
This pull request changes the Super-Linter image from `github/super-linter` to `super-linter/super-linter/slim`.
